### PR TITLE
fix: trust l1 rpc in op-node

### DIFF
--- a/src/cl/op-node/op_node_launcher.star
+++ b/src/cl/op-node/op_node_launcher.star
@@ -154,6 +154,7 @@ def get_beacon_config(
         "--l1={0}".format(l1_config_env_vars["L1_RPC_URL"]),
         "--l1.rpckind={0}".format(l1_config_env_vars["L1_RPC_KIND"]),
         "--l1.beacon={0}".format(l1_config_env_vars["CL_RPC_URL"]),
+        "--l1.trustrpc",
         "--p2p.advertise.ip=" + constants.PRIVATE_IP_ADDRESS_PLACEHOLDER,
         "--p2p.advertise.tcp={0}".format(BEACON_DISCOVERY_PORT_NUM),
         "--p2p.advertise.udp={0}".format(BEACON_DISCOVERY_PORT_NUM),


### PR DESCRIPTION
- get around lack of support for eth_getProof on local L1